### PR TITLE
Create a check for existence of key `ignore404` when sending requests

### DIFF
--- a/src/RemoteLRS.php
+++ b/src/RemoteLRS.php
@@ -144,7 +144,7 @@ class RemoteLRS implements LRSInterface
         $response['_metadata'] = $metadata;
 
         $success = false;
-        if (($response['status'] >= 200 && $response['status'] < 300) || ($response['status'] === 404 && $options['ignore404'])) {
+        if (($response['status'] >= 200 && $response['status'] < 300) || ($response['status'] === 404 && isset($options['ignore404']) && $options['ignore404'])) {
             $success = true;
         }
         elseif ($response['status'] >= 300 && $response['status'] < 400) {


### PR DESCRIPTION
The option does not seem to always be sent (only handled via State API requests it seems), leading to an unhandled exception on LRS endpoints that 404.
